### PR TITLE
Make the naming of the outputs more consistent

### DIFF
--- a/version/action.yaml
+++ b/version/action.yaml
@@ -5,11 +5,11 @@ outputs:
     value: ${{steps.version.outputs.VERSION}}
     description: Version from package.json, for easy reuse
   SHORT_HASH:
-    value: ${{steps.short-hash.outputs.SHORTHASH}}
+    value: ${{steps.short-hash.outputs.SHORT_HASH}}
     description: Short-hash from git commit, for easy matching back build to commit
-  VERSION-TAG:
+  VERSION_TAG:
     value: ${{steps.version-tag.outputs.VERSION_TAG}}
-    description: Combined version / shorthash for tagging of artifacts
+    description: Combined version / short hash for tagging of artifacts
 
 runs:
   using: "composite"
@@ -24,11 +24,11 @@ runs:
       id: short-hash
       shell: bash
       run: |
-        echo ::set-output name=SHORTHASH::$(git rev-parse --short "$GITHUB_SHA")
+        echo ::set-output name=SHORT_HASH::$(git rev-parse --short "$GITHUB_SHA")
     - name: Create version-tag
       id: version-tag
       shell: bash
       run: |
-        tag=${{ steps.version.outputs.VERSION }}-${{ steps.short-hash.outputs.SHORTHASH }}
+        tag=${{ steps.version.outputs.VERSION }}-${{ steps.short-hash.outputs.SHORT_HASH }}
         echo $tag
         echo "::set-output name=VERSION_TAG::$tag"


### PR DESCRIPTION
The naming of the short hash and version tag should be consistent.