### PR TITLE
Fix shallow clone issue

### DIFF
--- a/node-publish/action.yaml
+++ b/node-publish/action.yaml
@@ -6,17 +6,19 @@ inputs:
     description: "Your personal access token - PAT"
   NODE_CACHE:
     required: false
-    default: ''
+    default: ""
     description: "Set NODE_CACHE to 'npm' to enabled cached dependencies"
 runs:
   using: "composite"
   steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - name: Use Node.js Own version
       uses: actions/setup-node@v3
       with:
-        node-version-file: '.nvmrc'
-        cache:  ${{ inputs.NODE_CACHE }}
+        node-version-file: ".nvmrc"
+        cache: ${{ inputs.NODE_CACHE }}
       env:
         NPM_TOKEN: ${{ inputs.NPM_REGISTRY_TOKEN }}
     - name: npm publish


### PR DESCRIPTION
Message from SonarCloud
> Shallow clone detected during the analysis. Some files will miss SCM information. This will affect features like auto-assignment of issues. Please configure your build to disable shallow clone.