### PR TITLE
refactor set-output to $GITHUB_OUTPUT

### DIFF
--- a/docker-build/action.yaml
+++ b/docker-build/action.yaml
@@ -48,14 +48,14 @@ runs:
       run: |
         TAG=${{ inputs.DOCKER_TAG }}
         IMAGE="eu.gcr.io/${{ inputs.PROJECT_ID }}/${{ inputs.SERVICE_NAME }}"
-        echo ::set-output name=tagged_image::${IMAGE}:${TAG}
-        echo ::set-output name=tag::${TAG}
+        echo "tagged_image=${IMAGE}:${TAG}" >> $GITHUB_OUTPUT
+        echo "tag=${TAG}" >> $GITHUB_OUTPUT
     
     - name: Encode
       shell: bash
       id: encode
       run: |
-        echo ::set-output name=tagged_image_enc::$(echo -n '${{steps.prepare.outputs.tagged_image}}' | base64 -w0 | base64 -w0 )
+        echo "tagged_image_enc=$(echo -n '${{steps.prepare.outputs.tagged_image}}' | base64 -w0 | base64 -w0 )" >> $GITHUB_OUTPUT
 
     - name: Build development image
       uses: docker/build-push-action@v3

--- a/docker-image/action.yaml
+++ b/docker-image/action.yaml
@@ -26,11 +26,11 @@ runs:
       run: |
         TAG=${{ inputs.DOCKER_TAG }}
         IMAGE="eu.gcr.io/${{ inputs.PROJECT_ID }}/${{ inputs.SERVICE_NAME }}"
-        echo ::set-output name=tagged_image::${IMAGE}:${TAG}
-        echo ::set-output name=tag::${TAG}
+        echo "tagged_image=${IMAGE}:${TAG}" >> $GITHUB_OUTPUT
+        echo "tag=${TAG}" >> $GITHUB_OUTPUT
     
     - name: Encode
       shell: bash
       id: encode
       run: |
-        echo ::set-output name=tagged_image_enc::$(echo -n '${{steps.prepare.outputs.tagged_image}}' | base64 -w0 | base64 -w0 )
+        echo "tagged_image_enc=$(echo -n '${{steps.prepare.outputs.tagged_image}}' | base64 -w0 | base64 -w0 )" >> $GITHUB_OUTPUT

--- a/docker-retag/action.yaml
+++ b/docker-retag/action.yaml
@@ -32,7 +32,7 @@ runs:
       shell: bash
       id: decode
       run: |
-        echo ::set-output name=tagged_image_original::$(echo -n '${{ inputs.DOCKER_IMAGE_ENCODED}}' | base64 -d | base64 -d )
+        echo "tagged_image_original=$(echo -n '${{ inputs.DOCKER_IMAGE_ENCODED}}' | base64 -d | base64 -d )" >> $GITHUB_OUTPUT
 
     - id: "auth"
       uses: "google-github-actions/auth@v0"
@@ -55,14 +55,14 @@ runs:
       run: |
         TAG=${{ inputs.DOCKER_TAG }}
         IMAGE="eu.gcr.io/${{ inputs.PROJECT_ID }}/${{ inputs.SERVICE_NAME }}"
-        echo ::set-output name=tagged_image::${IMAGE}:${TAG}
-        echo ::set-output name=tag::${TAG}
+        echo "tagged_image=${IMAGE}:${TAG}" >> $GITHUB_OUTPUT
+        echo "tag=${TAG}" >> $GITHUB_OUTPUT
     
     - name: Encode
       shell: bash
       id: encode
       run: |
-        echo ::set-output name=tagged_image_enc::$(echo -n '${{steps.prepare.outputs.tagged_image}}' | base64 -w0 | base64 -w0 )
+        echo "tagged_image_enc=$(echo -n '${{steps.prepare.outputs.tagged_image}}' | base64 -w0 | base64 -w0 )" >> $GITHUB_OUTPUT
 
     - name: ReTag
       shell: bash

--- a/version/action.yaml
+++ b/version/action.yaml
@@ -19,16 +19,16 @@ runs:
       id: version
       shell: bash
       run: |
-        echo "::set-output name=VERSION::$(sed -nE 's/^\s*"version": "(.*?)",$/\1/p' package.json)"
+        echo "VERSION=$(sed -nE 's/^\s*"version": "(.*?)",$/\1/p' package.json)" >> $GITHUB_OUTPUT
     - name: Get short-hash
       id: short-hash
       shell: bash
       run: |
-        echo ::set-output name=SHORT_HASH::$(git rev-parse --short "$GITHUB_SHA")
+        echo "SHORT_HASH=$(git rev-parse --short "$GITHUB_SHA")" >> $GITHUB_OUTPUT
     - name: Create version-tag
       id: version-tag
       shell: bash
       run: |
         tag=${{ steps.version.outputs.VERSION }}-${{ steps.short-hash.outputs.SHORT_HASH }}
         echo $tag
-        echo "::set-output name=VERSION_TAG::$tag"
+        echo "VERSION_TAG=$tag" >> $GITHUB_OUTPUT

--- a/vue-dist/action.yml
+++ b/vue-dist/action.yml
@@ -28,7 +28,7 @@ runs:
   #   dist: ${{ env.DIST_NAME }}
   steps:
   - shell: bash
-    run: echo '::set-output name=NAME::dist.${{ inputs.version }}'
+    run: echo "NAME=dist.${{ inputs.version }}" >> $GITHUB_OUTPUT
     id: artifact-name
   - uses: actions/checkout@v3
   - name: Use Node.js


### PR DESCRIPTION
SEE: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/