### PR TITLE
Feature/wrangler node

### DIFF
--- a/cloudflare-publish/action.yaml
+++ b/cloudflare-publish/action.yaml
@@ -30,7 +30,7 @@ runs:
       name:  ${{ inputs.DIST_NAME }}
       path: output
   - name: Publish app
-    uses: cloudflare/wrangler-action-node@1.1.1
+    uses: demosjarco/wrangler-action-node@v1.1.1
     with:
       apiToken: ${{ inputs.CF_WRANGLER_TOKEN }}
       accountId: ${{ inputs.ACCOUNT_ID }}

--- a/cloudflare-publish/action.yaml
+++ b/cloudflare-publish/action.yaml
@@ -31,7 +31,7 @@ runs:
     with:
       apiToken: ${{ inputs.CF_WRANGLER_TOKEN }}
       accountId: ${{ inputs.ACCOUNT_ID }}
-      command: pages publish output --project-name cartman-frontend --branch ${{ inputs.BRANCH_NAME }} --commit-hash ${{ inputs.COMMIT_HASH }} | tee -a output.log
+      command: pages deploy output --project-name cartman-frontend --branch ${{ inputs.BRANCH_NAME }} --commit-hash ${{ inputs.COMMIT_HASH }} | tee -a output.log
   - name: Report output
     shell: bash
     run: tail -n 3 output.log >> $GITHUB_STEP_SUMMARY

--- a/cloudflare-publish/action.yaml
+++ b/cloudflare-publish/action.yaml
@@ -27,7 +27,7 @@ runs:
       name:  ${{ inputs.DIST_NAME }}
       path: output
   - name: Publish app
-    uses: cloudflare/wrangler-action@2.0.0
+    uses: cloudflare/wrangler-action-node@1.1.1
     with:
       apiToken: ${{ inputs.CF_WRANGLER_TOKEN }}
       accountId: ${{ inputs.ACCOUNT_ID }}

--- a/cloudflare-publish/action.yaml
+++ b/cloudflare-publish/action.yaml
@@ -2,20 +2,23 @@ name: "Cloudflare Publish"
 description: "Publish a static site to cloudflare using wrangler"
 
 inputs:
-  DIST_NAME:
-    description: "Name of the artifact to download"
+  ACCOUNT_ID:
+    description: "The account-id that has been registered at cloudflare"
     required: true
   BRANCH_NAME:
     description: "Branch name of this publication, special branches trigger live release..."
     required: true
+  CF_WRANGLER_TOKEN:
+    description: "The secret token created on cloudflare"
+    required: true
   COMMIT_HASH:
     description: "Commit hash (short) of this publication, an easy way to match your publication back to your commit"
     required: true
-  ACCOUNT_ID:
-    description: "The account-id that has been registered at cloudflare"
+  DIST_NAME:
+    description: "Name of the artifact to download"
     required: true
-  CF_WRANGLER_TOKEN:
-    description: "The secret token created on cloudflare"
+  PROJECT_NAME:
+    description: "The cloudflare registered project name"
     required: true
 
 runs:
@@ -31,7 +34,7 @@ runs:
     with:
       apiToken: ${{ inputs.CF_WRANGLER_TOKEN }}
       accountId: ${{ inputs.ACCOUNT_ID }}
-      command: pages deploy output --project-name cartman-frontend --branch ${{ inputs.BRANCH_NAME }} --commit-hash ${{ inputs.COMMIT_HASH }} | tee -a output.log
+      command: pages deploy output --project-name ${{ input.PROJECT_NAME }} --branch ${{ inputs.BRANCH_NAME }} --commit-hash ${{ inputs.COMMIT_HASH }} | tee -a output.log
   - name: Report output
     shell: bash
     run: tail -n 3 output.log >> $GITHUB_STEP_SUMMARY

--- a/cloudflare-publish/action.yaml
+++ b/cloudflare-publish/action.yaml
@@ -34,7 +34,7 @@ runs:
     with:
       apiToken: ${{ inputs.CF_WRANGLER_TOKEN }}
       accountId: ${{ inputs.ACCOUNT_ID }}
-      command: pages deploy output --project-name ${{ input.PROJECT_NAME }} --branch ${{ inputs.BRANCH_NAME }} --commit-hash ${{ inputs.COMMIT_HASH }} | tee -a output.log
+      command: pages deploy output --project-name ${{ inputs.PROJECT_NAME }} --branch ${{ inputs.BRANCH_NAME }} --commit-hash ${{ inputs.COMMIT_HASH }} | tee -a output.log
   - name: Report output
     shell: bash
     run: tail -n 3 output.log >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
- Fixes #16 by adding `PROJECT_NAME` input 
- Update to cleaner wrangler-action (which also reduces build-time by 2 minutes!!!)
- Using `deploy` instead of deprecated `publish`