### PR TITLE
Update sonarcloud-scan to latest version

### DIFF
--- a/sonarcloud/action.yaml
+++ b/sonarcloud/action.yaml
@@ -29,7 +29,7 @@ runs:
         CI: "true"
         NPM_TOKEN: ${{ inputs.NPM_REGISTRY_TOKEN }}
     - name: SonarCloud Scan
-      uses: sonarsource/sonarcloud-github-action@v1.8
+      uses: sonarsource/sonarcloud-github-action@master
       env:
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ inputs.SONAR_TOKEN }}


### PR DESCRIPTION
Due to outdated version of the Github Action the sonarcloud scan does not work as of today (15 jan 2024), because it still uses an older version of sonarcource packages. 

See: https://community.sonarsource.com/t/java-11-is-deprecated-as-a-runtime-env-to-scan-your-projects/96597

In this PR the action always uses the latest version of the GitHub Action and will stay up-to-date.