### PR TITLE
CRITICAL: fix/google-github-action-v0-deprication

### DIFF
--- a/docker-build/action.yaml
+++ b/docker-build/action.yaml
@@ -28,12 +28,12 @@ runs:
     - uses: actions/checkout@v3
 
     - id: "auth"
-      uses: "google-github-actions/auth@v0"
+      uses: "google-github-actions/auth@v2"
       with:
         credentials_json: "${{ inputs.GCP_SA_KEY }}"
 
     - name: Setup Cloud SDK
-      uses: google-github-actions/setup-gcloud@v0
+      uses: google-github-actions/setup-gcloud@v2
       with:
         project_id: ${{ inputs.PROJECT_ID }}
         export_default_credentials: true # Set to true to authenticate the Cloud Run action

--- a/docker-retag/action.yaml
+++ b/docker-retag/action.yaml
@@ -35,12 +35,12 @@ runs:
         echo "tagged_image_original=$(echo -n '${{ inputs.DOCKER_IMAGE_ENCODED}}' | base64 -d | base64 -d )" >> $GITHUB_OUTPUT
 
     - id: "auth"
-      uses: "google-github-actions/auth@v0"
+      uses: "google-github-actions/auth@v2"
       with:
         credentials_json: "${{ inputs.GCP_SA_KEY }}"
 
     - name: Setup Cloud SDK
-      uses: google-github-actions/setup-gcloud@v0
+      uses: google-github-actions/setup-gcloud@v2
       with:
         project_id: ${{ inputs.PROJECT_ID }}
         export_default_credentials: true # Set to true to authenticate the Cloud Run action


### PR DESCRIPTION
We're too far behind on our google-action dependencies, causing any of the actions in this PR to fail already.