### PR TITLE
Fix all github-actions that are deprecated at node 16

### DIFF
--- a/cloudflare-publish/action.yaml
+++ b/cloudflare-publish/action.yaml
@@ -25,7 +25,7 @@ runs:
   using: "composite"
   steps:
   - name: Download artifact
-    uses: actions/download-artifact@v3
+    uses: actions/download-artifact@v4
     with:
       name:  ${{ inputs.DIST_NAME }}
       path: output

--- a/docker-build/action.yaml
+++ b/docker-build/action.yaml
@@ -25,7 +25,7 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - id: "auth"
       uses: "google-github-actions/auth@v2"

--- a/node-publish/action.yaml
+++ b/node-publish/action.yaml
@@ -11,7 +11,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Use Node.js Own version

--- a/node-publish/action.yaml
+++ b/node-publish/action.yaml
@@ -15,7 +15,7 @@ runs:
       with:
         fetch-depth: 0
     - name: Use Node.js Own version
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version-file: ".nvmrc"
         cache: ${{ inputs.NODE_CACHE }}

--- a/nodejs/action.yaml
+++ b/nodejs/action.yaml
@@ -41,7 +41,7 @@ runs:
     - name: Cache node modules
       if: ${{ inputs.MODULES_CACHE == 'true' }}
       id: cache-nodemodules
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       env:
         cache-name: cache-node-modules
       with:

--- a/nodejs/action.yaml
+++ b/nodejs/action.yaml
@@ -19,7 +19,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         # Disabling shallow clone is recommended for improving relevancy of reporting
         fetch-depth: 0

--- a/nodejs/action.yaml
+++ b/nodejs/action.yaml
@@ -25,14 +25,14 @@ runs:
         fetch-depth: 0
     - name: Use Node.js - ${{ inputs.NODE_VERSION }}
       if: ${{ inputs.NODE_VERSION != '0' }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.NODE_VERSION }}
       env:
         NPM_TOKEN: ${{ inputs.NPM_REGISTRY_TOKEN }}
     - name: Use Node.js Own version
       if: ${{ inputs.NODE_VERSION == '0' }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version-file: '.nvmrc'
         cache:  ${{ inputs.NODE_CACHE }}

--- a/sonarcloud/action.yaml
+++ b/sonarcloud/action.yaml
@@ -15,7 +15,7 @@ runs:
   steps:
     - uses: actions/checkout@v4
     - name: Use Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version-file: '.nvmrc'
       env:

--- a/sonarcloud/action.yaml
+++ b/sonarcloud/action.yaml
@@ -13,7 +13,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Use Node.js
       uses: actions/setup-node@v3
       with:

--- a/vue-dist/action.yml
+++ b/vue-dist/action.yml
@@ -67,7 +67,7 @@ runs:
       CI: "true"
   - name: Archive production artifacts
     id: dist
-    uses: actions/upload-artifact@v3
+    uses: actions/upload-artifact@v4
     with:
       name: ${{steps.artifact-name.outputs.NAME}}
       retention-days: 3

--- a/vue-dist/action.yml
+++ b/vue-dist/action.yml
@@ -30,7 +30,7 @@ runs:
   - shell: bash
     run: echo "NAME=dist.${{ inputs.version }}" >> $GITHUB_OUTPUT
     id: artifact-name
-  - uses: actions/checkout@v3
+  - uses: actions/checkout@v4
   - name: Use Node.js
     uses: actions/setup-node@v3
     with:

--- a/vue-dist/action.yml
+++ b/vue-dist/action.yml
@@ -32,7 +32,7 @@ runs:
     id: artifact-name
   - uses: actions/checkout@v4
   - name: Use Node.js
-    uses: actions/setup-node@v3
+    uses: actions/setup-node@v4
     with:
       node-version-file: '.nvmrc'
       cache:  ${{ inputs.NODE_CACHE }}

--- a/vue-dist/action.yml
+++ b/vue-dist/action.yml
@@ -39,7 +39,7 @@ runs:
   - name: Cache node modules
     if: ${{ inputs.MODULES_CACHE == 'true' }}
     id: cache-nodemodules
-    uses: actions/cache@v3
+    uses: actions/cache@v4
     env:
       cache-name: cache-node-modules
     with:


### PR DESCRIPTION
To the requested reviewers, please check with your team if there's any potential issues resulting from these upgrades to V4, should not be, but just in case.