### PR TITLE
Feature/cloudflare back to original

### DIFF
--- a/cloudflare-publish/action.yaml
+++ b/cloudflare-publish/action.yaml
@@ -30,11 +30,12 @@ runs:
       name:  ${{ inputs.DIST_NAME }}
       path: output
   - name: Publish app
-    uses: demosjarco/wrangler-action-node@v1.1.1
+    uses: cloudflare/wrangler-action@v3
     with:
       apiToken: ${{ inputs.CF_WRANGLER_TOKEN }}
       accountId: ${{ inputs.ACCOUNT_ID }}
-      command: pages deploy output --project-name ${{ inputs.PROJECT_NAME }} --branch ${{ inputs.BRANCH_NAME }} --commit-hash ${{ inputs.COMMIT_HASH }} | tee -a output.log
+      preCommands: exec > >(tee output.log) 2>&1
+      command: pages deploy output --project-name ${{ inputs.PROJECT_NAME }} --branch ${{ inputs.BRANCH_NAME }} --commit-hash ${{ inputs.COMMIT_HASH }}
   - name: Report output
     shell: bash
     run: tail -n 3 output.log >> $GITHUB_STEP_SUMMARY

--- a/cloudflare-publish/action.yaml
+++ b/cloudflare-publish/action.yaml
@@ -31,11 +31,11 @@ runs:
       path: output
   - name: Publish app
     uses: cloudflare/wrangler-action@v3
+    id: wrangler
     with:
       apiToken: ${{ inputs.CF_WRANGLER_TOKEN }}
       accountId: ${{ inputs.ACCOUNT_ID }}
-      preCommands: exec > >(tee output.log) 2>&1
       command: pages deploy output --project-name ${{ inputs.PROJECT_NAME }} --branch ${{ inputs.BRANCH_NAME }} --commit-hash ${{ inputs.COMMIT_HASH }}
   - name: Report output
     shell: bash
-    run: tail -n 3 output.log >> $GITHUB_STEP_SUMMARY
+    run: echo "${{ steps.wrangler.outputs.command-output }}" | tail -n 3 >> $GITHUB_STEP_SUMMARY

--- a/cloudflare-publish/action.yaml
+++ b/cloudflare-publish/action.yaml
@@ -21,6 +21,14 @@ inputs:
     description: "The cloudflare registered project name"
     required: true
 
+outputs:
+  WRANGLER_OUT:
+    description: "The stdout logged from the wrangler action that was running"
+    value: ${{ steps.wrangler.outputs.command-output }}
+  CLOUDFLARE_URL:
+    description: "The URL of wranglers publication"
+    value: ${{ steps.url.outputs.CLOUDFLARE_URL }}
+
 runs:
   using: "composite"
   steps:
@@ -39,3 +47,7 @@ runs:
   - name: Report output
     shell: bash
     run: echo "${{ steps.wrangler.outputs.command-output }}" | tail -n 3 >> $GITHUB_STEP_SUMMARY
+  - name: Log URL
+    id: url
+    shell: bash
+    run: echo "CLOUDFLARE_URL=$(echo '${{ steps.wrangler.outputs.command-output }}' | tail -n 10 | grep -Eo 'https?://[^ >]+' | head -1)" >> $GITHUB_OUTPUT

--- a/cloudflare-publish/readme.md
+++ b/cloudflare-publish/readme.md
@@ -4,28 +4,41 @@ This composite action takes an artifact as input and publishes the contents to
 Cloudflare Pages. Depending on the setup of your Cloudflare environment it will
 either report a feature specific url, or it will publish to production.
 
-Works together with [vue-dist][vue] to publish static vue apps
-to cloudflare pages hosting.
+Works together with [vue-dist][vue] to publish static vue apps to cloudflare
+pages hosting. Any similar action that produces an artifact with a predictable
+static folder to publish can be used as input.
 
 ## Configuration
 
 To run this task the following settings are expected:
 
-- `DIST_NAME`:
-    description: "Name of the artifact to download",
+-  `ACCOUNT_ID`:
+    description: "The account-id that has been registered at cloudflare"
     required: true
-- `BRANCH_NAME`:
-    description: "Branch name of this publication, special branches trigger live release...",
+-  `BRANCH_NAME`:
+    description: "Branch name of this publication, special branches trigger live release..."
     required: true
-- `COMMIT_HASH`:
-    description: "Commit hash (short) of this publication, an easy way to match your publication back to your commit",
+-  `CF_WRANGLER_TOKEN`:
+    description: "The secret token created on cloudflare"
     required: true
-- `ACCOUNT_ID`:
-    description: "The account-id that has been registered at cloudflare",
+-  `COMMIT_HASH`:
+    description: "Commit hash (short) of this publication, an easy way to match your publication back to your commit"
     required: true
-- `CF_WRANGLER_TOKEN`:
-    description: "The secret token created on cloudflare",
+-  `DIST_NAME`:
+    description: "Name of the artifact to download"
     required: true
+-  `PROJECT_NAME`:
+    description: "The cloudflare registered project name"
+    required: true
+
+Outputs:
+
+-  `WRANGLER_OUT`:
+    description: "The stdout logged from the wrangler action that was running"
+    value: ${{ steps.wrangler.outputs.command-output }}
+-  `CLOUDFLARE_URL`:
+    description: "The URL of wranglers publication"
+    value: ${{ steps.url.outputs.CLOUDFLARE_URL }}
 
 ## Usage
 
@@ -40,13 +53,16 @@ This example uses this action and passes the artefact name to a publication acti
     needs: [dist, version]
     runs-on: ubuntu-latest
     steps:
-    - uses:  pondevelopment/actions/cloudflare-publish@feature/cloudflare
+    - uses:  pondevelopment/actions/cloudflare-publish@v1.1
       with:
-        DIST_NAME:  ${{ needs.dist.outputs.dist }}
-        BRANCH_NAME: env.BRANCH_NAME
+        DIST_NAME: ${{ needs.dist.outputs.dist }}
+        BRANCH_NAME: ${{ env.BRANCH_NAME }}
+        PROJECT_NAME: your-project-name
         COMMIT_HASH: ${{ needs.version.outputs.SHORT_HASH }}
-        ACCOUNT_ID: 1234b123e4a1a12345ff01aa4321f12a
-        CF_WRANGLER_TOKEN: ${{ secrets.CF_WRANGLER_TOKEN }}
+        ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+        CF_WRANGLER_TOKEN: ${{ secrets.CF_API_TOKEN }}
+    outputs:
+      cloudflare_url: ${{ steps.cloudflare.outputs.CLOUDFLARE_URL }}
 ```
 
 [vue]: ../vue-dist/readme.md


### PR DESCRIPTION
With the recent string of updates in dependencies, this particular action was found to depend on a deprecated action. The original 'branded' action has since been updated to work nearly as fast.

We've had to rework how we pass along the url from the publication to following steps and found that the latest official wrangler action already has `command-output` to work with in further steps.

This run on a depending repo proofs it works as expected: https://github.com/ponbike/b2b-privatelease-frontend/actions/runs/8156822624/job/22295170122